### PR TITLE
feat: allow modifier quantity

### DIFF
--- a/src/helpers/item.ts
+++ b/src/helpers/item.ts
@@ -174,8 +174,18 @@ export class Item {
 		let selectedValueCount = (<TextModifier>selectedModifier)?.textEntry?.length || 0;
 		if ((<ChoiceModifier>selectedModifier)?.choiceSelections?.length) {
 			// Invalid or sold out choices
-			const invalidChoice = (<ChoiceModifier>selectedModifier).choiceSelections.find(s => !modifierList.modifiers?.find(m => m.id === s));
-			const soldOutChoice = (<ChoiceModifier>selectedModifier).choiceSelections.find(s => modifierList.modifiers?.find(m => m.id === s)?.sold_out);
+			const invalidChoice = (<ChoiceModifier>selectedModifier).choiceSelections.find(s => !modifierList.modifiers?.find(m => {
+				if (typeof s === 'object') {
+					return m.id === s.id;
+				}
+				return m.id === s;
+			}));
+			const soldOutChoice = (<ChoiceModifier>selectedModifier).choiceSelections.find(s => modifierList.modifiers?.find(m => {
+				if (typeof s === 'object') {
+					return m.id === s.id;
+				}
+				return m.id === s;
+			})?.sold_out);
 			if (invalidChoice || soldOutChoice) {
 				return false;
 			}
@@ -322,9 +332,18 @@ export class Item {
 					const matchingModifierList = item.modifier_lists?.find(l => l.id === selectedModifier.id);
 					if (matchingModifierList) {
 						matchingModifierList.modifiers?.forEach(m => {
-							if (selectedModifier.choiceSelections.includes(m.id) && m.price_money) {
-								regularPrice += m.price_money.amount;
-								salePrice += m.price_money.amount;
+							let quantity = 1;
+							if (selectedModifier.choiceSelections.find(s => {
+								if (typeof s === 'object') {
+									if (m.id === s.id) {
+										quantity = s.quantity;
+										return true;
+									}
+								}
+								return m.id === s;
+							}) && m.price_money) {
+								regularPrice += m.price_money.amount * quantity;
+								salePrice += m.price_money.amount * quantity;
 							}
 						});
 					}

--- a/src/types/api/cart/index.ts
+++ b/src/types/api/cart/index.ts
@@ -92,7 +92,7 @@ export interface ChoiceModifier extends BaseModifier {
 	/** The modifier type. */
 	type: 'CHOICE';
 	/** Choice selections for modifier. */
-	choiceSelections: string[];
+	choiceSelections: Choice[];
 }
 
 export interface TextModifier extends BaseModifier {
@@ -106,7 +106,14 @@ export interface GiftWrapModifier extends BaseModifier {
 	/** The modifier type. */
 	type: 'GIFT_WRAP';
 	/** Choice selections for modifier. */
-	choiceSelections: string[];
+	choiceSelections: Choice[];
+}
+
+export type Choice = string | ChoiceSelection;
+
+export interface ChoiceSelection {
+	id: string;
+	quantity: number;
 }
 
 export interface GiftMessageModifier extends BaseModifier {

--- a/typedocs/interfaces/types_api_cart.ChoiceModifier.md
+++ b/typedocs/interfaces/types_api_cart.ChoiceModifier.md
@@ -42,6 +42,6 @@ ___
 
 ### choiceSelections
 
-• **choiceSelections**: `string`[]
+• **choiceSelections**: [`Choice`](../modules/types_api_cart.md#choice)[]
 
 Choice selections for modifier.

--- a/typedocs/interfaces/types_api_cart.ChoiceSelection.md
+++ b/typedocs/interfaces/types_api_cart.ChoiceSelection.md
@@ -1,0 +1,24 @@
+[@square/site-theme-sdk](../GettingStarted.md) / [Modules](../modules.md) / [types/api/cart](../modules/types_api_cart.md) / ChoiceSelection
+
+# Interface: ChoiceSelection
+
+[types/api/cart](../modules/types_api_cart.md).ChoiceSelection
+
+## Table of contents
+
+### Properties
+
+- [id](types_api_cart.ChoiceSelection.md#id)
+- [quantity](types_api_cart.ChoiceSelection.md#quantity)
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+___
+
+### quantity
+
+• **quantity**: `number`

--- a/typedocs/interfaces/types_api_cart.GiftWrapModifier.md
+++ b/typedocs/interfaces/types_api_cart.GiftWrapModifier.md
@@ -42,6 +42,6 @@ ___
 
 ### choiceSelections
 
-• **choiceSelections**: `string`[]
+• **choiceSelections**: [`Choice`](../modules/types_api_cart.md#choice)[]
 
 Choice selections for modifier.

--- a/typedocs/modules/types_api_cart.md
+++ b/typedocs/modules/types_api_cart.md
@@ -12,6 +12,7 @@
 - [ChoiceModifier](../interfaces/types_api_cart.ChoiceModifier.md)
 - [TextModifier](../interfaces/types_api_cart.TextModifier.md)
 - [GiftWrapModifier](../interfaces/types_api_cart.GiftWrapModifier.md)
+- [ChoiceSelection](../interfaces/types_api_cart.ChoiceSelection.md)
 - [GiftMessageModifier](../interfaces/types_api_cart.GiftMessageModifier.md)
 - [AddLineItem](../interfaces/types_api_cart.AddLineItem.md)
 - [BuyNowSubscriptionLineItem](../interfaces/types_api_cart.BuyNowSubscriptionLineItem.md)
@@ -34,6 +35,7 @@
 - [ScheduleTypeEnum](types_api_cart.md#scheduletypeenum)
 - [ModifierTypeEnum](types_api_cart.md#modifiertypeenum)
 - [CurrencyTypeEnum](types_api_cart.md#currencytypeenum)
+- [Choice](types_api_cart.md#choice)
 - [AddItemModifier](types_api_cart.md#additemmodifier)
 - [BuyNowSubscriptionItemModifier](types_api_cart.md#buynowsubscriptionitemmodifier)
 
@@ -67,6 +69,12 @@ ___
 ### CurrencyTypeEnum
 
 Ƭ **CurrencyTypeEnum**: typeof [`CurrencyType`](types_api_cart.md#currencytype)[keyof typeof [`CurrencyType`](types_api_cart.md#currencytype)]
+
+___
+
+### Choice
+
+Ƭ **Choice**: `string` \| [`ChoiceSelection`](../interfaces/types_api_cart.ChoiceSelection.md)
 
 ___
 


### PR DESCRIPTION
In preparation for modifier quantities, allow the SDK to accept an array of strings (existing behaviour) or an array of `ChoiceSelection` objects.

Note that at the moment, the platform will only accept a modifier quantity of 1.